### PR TITLE
Update bake files to latest

### DIFF
--- a/ruby/2.7-fat/docker-bake.hcl
+++ b/ruby/2.7-fat/docker-bake.hcl
@@ -1,6 +1,5 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
-
 variable "PWD" {default="" }
 variable "CI_BUILDX_CACHE" {default=false }
 
@@ -12,7 +11,7 @@ group "default" {
 target "ruby" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.6-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.6-fat-jammy"]
     context = "${PWD}/ruby/2.7-fat"
-    platforms = ["linux/arm64"]
+    platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
     cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
 }

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -1,6 +1,5 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
-
 variable "PWD" {default="" }
 variable "CI_BUILDX_CACHE" {default=false }
 

--- a/ruby/3.0-fat/docker-bake.hcl
+++ b/ruby/3.0-fat/docker-bake.hcl
@@ -1,6 +1,5 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
-
 variable "PWD" {default="" }
 variable "CI_BUILDX_CACHE" {default=false }
 

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -1,6 +1,5 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
-
 variable "PWD" {default="" }
 variable "CI_BUILDX_CACHE" {default=false }
 

--- a/ruby/3.1-fat/docker-bake.hcl
+++ b/ruby/3.1-fat/docker-bake.hcl
@@ -1,6 +1,5 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
-
 variable "PWD" {default="" }
 variable "CI_BUILDX_CACHE" {default=false }
 

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -1,6 +1,5 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
-
 variable "PWD" {default="" }
 variable "CI_BUILDX_CACHE" {default=false }
 

--- a/ruby/template/docker-bake.hcl
+++ b/ruby/template/docker-bake.hcl
@@ -9,7 +9,7 @@ ruby_tags = [
 ]
 ruby_tags.push("#{full_ecr_path}:#{ruby_version}") if flavor&.casecmp('slim')&.zero?
 custom_tags = docker_tags(ruby_tags)
-%>
+-%>
 
 variable "PWD" {default="" }
 variable "CI_BUILDX_CACHE" {default=false }


### PR DESCRIPTION
Looks like there was a typo in 2.7-fat and we were missing the amd64 build of that image.