### PR TITLE
Add docker to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,96 @@
----
 version: 2
+
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 1
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+      interval: daily
     labels:
-      - "dependencies"
-    open-pull-requests-limit: 5
+      - dependencies
     reviewers:
-      - "get-bridge/oberbaum"
+      - get-bridge/oberbaum
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    reviewers:
+      - get-bridge/oberbaum
+
+  # These are not meant to be automatically accepted
+  # because they're templated files, however this will
+  # give us a way to be automatically notified when there
+  # are upstream changes to roll into our own templates.
+  - package-ecosystem: docker
+    directory: core/jammy/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender
+
+  - package-ecosystem: docker
+    directory: core/jammy-fat/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender
+
+  - package-ecosystem: docker
+    directory: ruby/2.7/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender
+
+  - package-ecosystem: docker
+    directory: ruby/2.7-fat/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender
+
+  - package-ecosystem: docker
+    directory: ruby/3.0/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender
+
+  - package-ecosystem: docker
+    directory: ruby/3.0-fat/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender
+
+  - package-ecosystem: docker
+    directory: ruby/3.1/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender
+
+  - package-ecosystem: docker
+    directory: ruby/3.1-fat/Dockerfile
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+    assignees:
+      - djbender

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ We use `ruby` , and `erb` templates to generate our Dockerfile's
 - `bundle install`
 - `bundle exec rake -T` to see rake tasks
 
-
 You can install some useful git-hooks by install [overcommit](https://github.com/sds/overcommit#installation)
 - `gem install overcommit`
 - `cp .overcommit.sample.yml .overcommit.yml`


### PR DESCRIPTION
These are not meant to be automatically accepted because they're templated files, however this will give us a way to be automatically notified when there are upstream changes to roll into our own templates. As such, I've assigned these pull requests to myself only since I know how to quickly handle them.

Fix: #11