### PR TITLE
Remove sudo

### DIFF
--- a/core/jammy-fat/Dockerfile
+++ b/core/jammy-fat/Dockerfile
@@ -24,8 +24,7 @@ apt install -qqy --no-install-recommends \
   curl \
   golang \
   make \
-  tar \
-  sudo
+  tar
 update-ca-certificates
 curl -L https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.tar.gz -o tini-$TINI_VERSION.tar.gz
 tar -xf tini-$TINI_VERSION.tar.gz
@@ -56,7 +55,6 @@ apt install -qqy --no-install-recommends \
   ca-certificates \
   curl \
   locales \
-  sudo \
   vim-tiny
 update-ca-certificates
 # See the Locals heading at https://hub.docker.com/_/ubuntu

--- a/core/jammy/Dockerfile
+++ b/core/jammy/Dockerfile
@@ -24,8 +24,7 @@ apt install -qqy --no-install-recommends \
   curl \
   golang \
   make \
-  tar \
-  sudo
+  tar
 update-ca-certificates
 curl -L https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.tar.gz -o tini-$TINI_VERSION.tar.gz
 tar -xf tini-$TINI_VERSION.tar.gz
@@ -56,7 +55,6 @@ apt install -qqy --no-install-recommends \
   ca-certificates \
   curl \
   locales \
-  sudo \
   vim-tiny
 update-ca-certificates
 # See the Locals heading at https://hub.docker.com/_/ubuntu

--- a/core/template/Dockerfile
+++ b/core/template/Dockerfile
@@ -22,8 +22,7 @@ apt install -qqy --no-install-recommends \
   curl \
   golang \
   make \
-  tar \
-  sudo
+  tar
 update-ca-certificates
 curl -L https://github.com/krallin/tini/archive/refs/tags/$TINI_VERSION.tar.gz -o tini-$TINI_VERSION.tar.gz
 tar -xf tini-$TINI_VERSION.tar.gz
@@ -54,7 +53,6 @@ apt install -qqy --no-install-recommends \
   ca-certificates \
   curl \
   locales \
-  sudo \
   vim-tiny
 update-ca-certificates
 # See the Locals heading at https://hub.docker.com/_/ubuntu


### PR DESCRIPTION
Per the [best practices doc](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user), it is recommend we avoid using sudo inside containers:

>Avoid installing or using sudo as it has unpredictable TTY and signal-forwarding behavior that can cause problems. If you absolutely need functionality similar to sudo, such as initializing the daemon as root but running it as non-root, consider using [“gosu”](https://github.com/tianon/gosu).

I'm unable to see any obvious hard constraint on requiring sudo in these images so I'm also inclined to remove it.

Fix: #18