### PR TITLE
Fix openssl install with impish->focal

### DIFF
--- a/ruby/2.7-fat/Dockerfile
+++ b/ruby/2.7-fat/Dockerfile
@@ -26,13 +26,13 @@ RUN <<EOT
     arch=$(dpkg --print-architecture)
   if [ "$arch" == "arm64" ]; then
     # Ruby versions older than or equal to 3.0 require an older version of openssl :| which is really annoying
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted" >> /etc/apt/sources.list
   else
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://security.ubuntu.com/ubuntu/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://security.ubuntu.com/ubuntu/ focal-security main restricted" >> /etc/apt/sources.list
   fi
   apt update
   apt install -qqy --allow-downgrades \

--- a/ruby/2.7/Dockerfile
+++ b/ruby/2.7/Dockerfile
@@ -26,13 +26,13 @@ RUN <<EOT
     arch=$(dpkg --print-architecture)
   if [ "$arch" == "arm64" ]; then
     # Ruby versions older than or equal to 3.0 require an older version of openssl :| which is really annoying
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted" >> /etc/apt/sources.list
   else
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://security.ubuntu.com/ubuntu/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://security.ubuntu.com/ubuntu/ focal-security main restricted" >> /etc/apt/sources.list
   fi
   apt update
   apt install -qqy --allow-downgrades \

--- a/ruby/3.0-fat/Dockerfile
+++ b/ruby/3.0-fat/Dockerfile
@@ -26,13 +26,13 @@ RUN <<EOT
     arch=$(dpkg --print-architecture)
   if [ "$arch" == "arm64" ]; then
     # Ruby versions older than or equal to 3.0 require an older version of openssl :| which is really annoying
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted" >> /etc/apt/sources.list
   else
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://security.ubuntu.com/ubuntu/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://security.ubuntu.com/ubuntu/ focal-security main restricted" >> /etc/apt/sources.list
   fi
   apt update
   apt install -qqy --allow-downgrades \

--- a/ruby/3.0/Dockerfile
+++ b/ruby/3.0/Dockerfile
@@ -26,13 +26,13 @@ RUN <<EOT
     arch=$(dpkg --print-architecture)
   if [ "$arch" == "arm64" ]; then
     # Ruby versions older than or equal to 3.0 require an older version of openssl :| which is really annoying
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted" >> /etc/apt/sources.list
   else
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://security.ubuntu.com/ubuntu/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://security.ubuntu.com/ubuntu/ focal-security main restricted" >> /etc/apt/sources.list
   fi
   apt update
   apt install -qqy --allow-downgrades \

--- a/ruby/template/Dockerfile
+++ b/ruby/template/Dockerfile
@@ -28,13 +28,13 @@ RUN <<EOT
   arch=$(dpkg --print-architecture)
   if [ "$arch" == "arm64" ]; then
     # Ruby versions older than or equal to 3.0 require an older version of openssl :| which is really annoying
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted" >> /etc/apt/sources.list
   else
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish main restricted" >> /etc/apt/sources.list
-    echo "deb http://archive.ubuntu.com/ubuntu/ impish-updates main restricted" >> /etc/apt/sources.list
-    echo "deb http://security.ubuntu.com/ubuntu/ impish-security main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" >> /etc/apt/sources.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted" >> /etc/apt/sources.list
+    echo "deb http://security.ubuntu.com/ubuntu/ focal-security main restricted" >> /etc/apt/sources.list
   fi
   apt update
   apt install -qqy --allow-downgrades \


### PR DESCRIPTION
Currently the build will fail because impish has met its EOL date. Unfortunately that means we have to downgrade even further to focal. I would not say this is not ideal but it is the best option we have right now.