### PR TITLE
Use GHA cache

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -41,6 +41,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
+          buildkitd-flags: --debug
           install: true
 
       - name: Login to ECR
@@ -98,6 +99,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
+          buildkitd-flags: --debug
           install: true
 
       - name: Login to ECR

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -57,8 +57,7 @@ jobs:
         uses: docker/bake-action@v2.2.0
         with:
           pull: true
-          push: true
-          # push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.core-paths }}
 
   set-outputs:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,7 +62,8 @@ jobs:
   set-outputs:
     runs-on: ubuntu-latest
     needs: build-core-images
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: false
+    # if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -79,9 +80,9 @@ jobs:
   build-all-images:
     needs: set-outputs
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: false
+    # if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
-      max-parallel: 4
       matrix:
         ci-files: ${{ fromJSON(needs.set-outputs.outputs.matrix) }}
     steps:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -82,7 +82,6 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
-      max-parallel: 4
       matrix:
         ci-files: ${{ fromJSON(needs.set-outputs.outputs.matrix) }}
     steps:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -15,7 +15,6 @@ env:
   ECR_REGISTRY: 127178877223.dkr.ecr.us-east-2.amazonaws.com
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
-  CI_BUILDX_CACHE: true
 
 jobs:
   build-core-images:
@@ -53,30 +52,12 @@ jobs:
         env:
           AWS_REGION: ${{ env.ECR_AWS_DEFAULT_REGION }}
 
-      - name: Cache Docker layers
-        if: ${{ env.CI_BUILDX_CACHE }}
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ matrix.core-paths }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.core-paths }}-buildx-
-
       - name: Build and push
         uses: docker/bake-action@v2.2.0
         with:
           pull: true
           push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.core-paths }}
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache(docker layers)
-        if: ${{ env.CI_BUILDX_CACHE }}
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   set-outputs:
     runs-on: ubuntu-latest
@@ -127,27 +108,9 @@ jobs:
         env:
           AWS_REGION: ${{ env.ECR_AWS_DEFAULT_REGION }}
 
-      - name: Cache Docker layers
-        if: ${{ env.CI_BUILDX_CACHE }}
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ matrix.ci-files }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ci-files }}-buildx-
-
       - name: Build and push
         uses: docker/bake-action@v2.2.0
         with:
           pull: true
           push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.ci-files }}
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache(docker layers)
-        if: ${{ env.CI_BUILDX_CACHE }}
-        run: |
-          rm -rf /tmp/.buildx-cache || true
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -57,7 +57,8 @@ jobs:
         uses: docker/bake-action@v2.2.0
         with:
           pull: true
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
+          # push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.core-paths }}
 
   set-outputs:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,8 +62,7 @@ jobs:
   set-outputs:
     runs-on: ubuntu-latest
     needs: build-core-images
-    if: false
-    # if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -80,9 +79,9 @@ jobs:
   build-all-images:
     needs: set-outputs
     runs-on: ubuntu-latest
-    if: false
-    # if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
+      max-parallel: 4
       matrix:
         ci-files: ${{ fromJSON(needs.set-outputs.outputs.matrix) }}
     steps:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -63,8 +63,7 @@ jobs:
   set-outputs:
     runs-on: ubuntu-latest
     needs: build-core-images
-    if: false
-    # if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -81,9 +80,9 @@ jobs:
   build-all-images:
     needs: set-outputs
     runs-on: ubuntu-latest
-    if: false
-    # if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
+      max-parallel: 4
       matrix:
         ci-files: ${{ fromJSON(needs.set-outputs.outputs.matrix) }}
     steps:

--- a/core/jammy-fat/docker-bake.hcl
+++ b/core/jammy-fat/docker-bake.hcl
@@ -17,9 +17,9 @@ target "core" {
     context = "${PWD}/core/jammy-fat"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=core/jammy-fat"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=core/jammy-fat"
+        "type=gha,scope=core/jammy-fat,mode=max"
     ]
 }

--- a/core/jammy-fat/docker-bake.hcl
+++ b/core/jammy-fat/docker-bake.hcl
@@ -20,6 +20,6 @@ target "core" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=core/jammy-fat"
     ]
 }

--- a/core/jammy-fat/docker-bake.hcl
+++ b/core/jammy-fat/docker-bake.hcl
@@ -6,7 +6,6 @@
 
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["core"]
@@ -17,6 +16,10 @@ target "core" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:jammy-fat"]
     context = "${PWD}/core/jammy-fat"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/core/jammy/docker-bake.hcl
+++ b/core/jammy/docker-bake.hcl
@@ -20,6 +20,6 @@ target "core" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=core/jammy"
     ]
 }

--- a/core/jammy/docker-bake.hcl
+++ b/core/jammy/docker-bake.hcl
@@ -17,9 +17,9 @@ target "core" {
     context = "${PWD}/core/jammy"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=core/jammy"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=core/jammy"
+        "type=gha,scope=core/jammy,mode=max"
     ]
 }

--- a/core/jammy/docker-bake.hcl
+++ b/core/jammy/docker-bake.hcl
@@ -6,7 +6,6 @@
 
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["core"]
@@ -17,6 +16,10 @@ target "core" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:jammy-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:latest"]
     context = "${PWD}/core/jammy"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/core/template/docker-bake.hcl
+++ b/core/template/docker-bake.hcl
@@ -8,7 +8,6 @@ custom_tags = docker_tags(core_tags)
 %>
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["<%= image_name %>"]
@@ -19,6 +18,10 @@ target "<%= image_name %>" {
     tags = <%= custom_tags %>
     context = "${PWD}/<%= image_name %>/<%= version %>"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/core/template/docker-bake.hcl
+++ b/core/template/docker-bake.hcl
@@ -22,6 +22,6 @@ target "<%= image_name %>" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=<%= image_name %>/<%= version %>"
     ]
 }

--- a/core/template/docker-bake.hcl
+++ b/core/template/docker-bake.hcl
@@ -19,9 +19,9 @@ target "<%= image_name %>" {
     context = "${PWD}/<%= image_name %>/<%= version %>"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=<%= image_name %>/<%= version %>"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=<%= image_name %>/<%= version %>"
+        "type=gha,scope=<%= image_name %>/<%= version %>,mode=max"
     ]
 }

--- a/ruby/2.7-fat/docker-bake.hcl
+++ b/ruby/2.7-fat/docker-bake.hcl
@@ -16,9 +16,9 @@ target "ruby" {
     context = "${PWD}/ruby/2.7-fat"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=ruby/2.7-fat"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=ruby/2.7-fat"
+        "type=gha,scope=ruby/2.7-fat,mode=max"
     ]
 }

--- a/ruby/2.7-fat/docker-bake.hcl
+++ b/ruby/2.7-fat/docker-bake.hcl
@@ -5,7 +5,6 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["ruby"]
@@ -16,6 +15,10 @@ target "ruby" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.6-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.6-fat-jammy"]
     context = "${PWD}/ruby/2.7-fat"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/ruby/2.7-fat/docker-bake.hcl
+++ b/ruby/2.7-fat/docker-bake.hcl
@@ -19,6 +19,6 @@ target "ruby" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=ruby/2.7-fat"
     ]
 }

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -19,6 +19,6 @@ target "ruby" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=ruby/2.7"
     ]
 }

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -16,9 +16,9 @@ target "ruby" {
     context = "${PWD}/ruby/2.7"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=ruby/2.7"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=ruby/2.7"
+        "type=gha,scope=ruby/2.7,mode=max"
     ]
 }

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -5,7 +5,6 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["ruby"]
@@ -16,6 +15,10 @@ target "ruby" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.6", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.6-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.6-slim-jammy"]
     context = "${PWD}/ruby/2.7"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/ruby/3.0-fat/docker-bake.hcl
+++ b/ruby/3.0-fat/docker-bake.hcl
@@ -5,7 +5,6 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["ruby"]
@@ -16,6 +15,10 @@ target "ruby" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.4-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.4-fat-jammy"]
     context = "${PWD}/ruby/3.0-fat"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/ruby/3.0-fat/docker-bake.hcl
+++ b/ruby/3.0-fat/docker-bake.hcl
@@ -16,9 +16,9 @@ target "ruby" {
     context = "${PWD}/ruby/3.0-fat"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=ruby/3.0-fat"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=ruby/3.0-fat"
+        "type=gha,scope=ruby/3.0-fat,mode=max"
     ]
 }

--- a/ruby/3.0-fat/docker-bake.hcl
+++ b/ruby/3.0-fat/docker-bake.hcl
@@ -19,6 +19,6 @@ target "ruby" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=ruby/3.0-fat"
     ]
 }

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -19,6 +19,6 @@ target "ruby" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=ruby/3.0"
     ]
 }

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -16,9 +16,9 @@ target "ruby" {
     context = "${PWD}/ruby/3.0"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=ruby/3.0"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=ruby/3.0"
+        "type=gha,scope=ruby/3.0,mode=max"
     ]
 }

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -5,7 +5,6 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["ruby"]
@@ -16,6 +15,10 @@ target "ruby" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.4", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.4-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.4-slim-jammy"]
     context = "${PWD}/ruby/3.0"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/ruby/3.1-fat/docker-bake.hcl
+++ b/ruby/3.1-fat/docker-bake.hcl
@@ -19,6 +19,6 @@ target "ruby" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=ruby/3.1-fat"
     ]
 }

--- a/ruby/3.1-fat/docker-bake.hcl
+++ b/ruby/3.1-fat/docker-bake.hcl
@@ -5,7 +5,6 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["ruby"]
@@ -16,6 +15,10 @@ target "ruby" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.2-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.2-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:latest"]
     context = "${PWD}/ruby/3.1-fat"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/ruby/3.1-fat/docker-bake.hcl
+++ b/ruby/3.1-fat/docker-bake.hcl
@@ -16,9 +16,9 @@ target "ruby" {
     context = "${PWD}/ruby/3.1-fat"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=ruby/3.1-fat"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=ruby/3.1-fat"
+        "type=gha,scope=ruby/3.1-fat,mode=max"
     ]
 }

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -19,6 +19,6 @@ target "ruby" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=ruby/3.1"
     ]
 }

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -5,7 +5,6 @@
 # https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["ruby"]
@@ -16,6 +15,10 @@ target "ruby" {
     tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.2", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.2-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.2-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:latest"]
     context = "${PWD}/ruby/3.1"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -16,9 +16,9 @@ target "ruby" {
     context = "${PWD}/ruby/3.1"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=ruby/3.1"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=ruby/3.1"
+        "type=gha,scope=ruby/3.1,mode=max"
     ]
 }

--- a/ruby/template/docker-bake.hcl
+++ b/ruby/template/docker-bake.hcl
@@ -14,7 +14,6 @@ custom_tags = docker_tags(ruby_tags)
 -%>
 
 variable "PWD" {default="" }
-variable "CI_BUILDX_CACHE" {default=false }
 
 group "default" {
     targets = ["<%= image_name %>"]
@@ -25,6 +24,10 @@ target "<%= image_name %>" {
     tags = <%= custom_tags %>
     context = "${PWD}/<%= image_name %>/<%= version %>"
     platforms = ["linux/amd64", "linux/arm64"]
-    cache-from = [equal(true,CI_BUILDX_CACHE) ? "type=local,src=/tmp/.buildx-cache": "",]
-    cache-to = [equal(true,CI_BUILDX_CACHE) ? "type=local,dest=/tmp/.buildx-cache-new,mode=max": ""]
+    cache-from = [
+        "type=gha"
+    ]
+    cache-to = [
+        "type=gha,mode=max"
+    ]
 }

--- a/ruby/template/docker-bake.hcl
+++ b/ruby/template/docker-bake.hcl
@@ -28,6 +28,6 @@ target "<%= image_name %>" {
         "type=gha"
     ]
     cache-to = [
-        "type=gha,mode=max"
+        "type=gha,mode=max,scope=<%= image_name %>/<%= version %>"
     ]
 }

--- a/ruby/template/docker-bake.hcl
+++ b/ruby/template/docker-bake.hcl
@@ -25,9 +25,9 @@ target "<%= image_name %>" {
     context = "${PWD}/<%= image_name %>/<%= version %>"
     platforms = ["linux/amd64", "linux/arm64"]
     cache-from = [
-        "type=gha"
+        "type=gha,scope=<%= image_name %>/<%= version %>"
     ]
     cache-to = [
-        "type=gha,mode=max,scope=<%= image_name %>/<%= version %>"
+        "type=gha,scope=<%= image_name %>/<%= version %>,mode=max"
     ]
 }


### PR DESCRIPTION
This will simplify caching code by using the buildkit builtin `gha` cache type. It should also be faster since there's no extra steps of writing to local disk. Buildkit imports the cache layers directly to the daemon.