### PR TITLE
Reorganize build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -88,7 +88,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        ci-files: ${{ fromJSON(needs.set-outputs.outputs.matrix) }}
+        ci-files: ${{ fromJSON(steps.set-outputs.outputs.MATRIX) }}
     steps:
       - name: set PWD environt variable
         run:  echo "PWD=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -64,11 +64,11 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           files: ${{ matrix.core-paths }}
 
-  set-outputs:
+  set-matrix:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.set-matrix.outputs.MATRIX }}
     steps:
       - uses: actions/checkout@v3
 
@@ -84,11 +84,11 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-core-images
-      - set-outputs
+      - set-matrix
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        ci-files: ${{ fromJSON(steps.set-outputs.outputs.MATRIX) }}
+        ci-files: ${{ fromJSON(needs.set-matrix.outputs.MATRIX) }}
     steps:
       - name: set PWD environt variable
         run:  echo "PWD=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -66,7 +66,6 @@ jobs:
 
   set-outputs:
     runs-on: ubuntu-latest
-    needs: build-core-images
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -82,8 +81,10 @@ jobs:
         run: bundle exec rake ci:set-matrix
 
   build-all-images:
-    needs: set-outputs
     runs-on: ubuntu-latest
+    needs:
+      - build-core-images
+      - set-outputs
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.MATRIX }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
 
@@ -88,7 +88,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        ci-files: ${{ fromJSON(needs.set-matrix.outputs.MATRIX) }}
+        ci-files: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     steps:
       - name: set PWD environt variable
         run:  echo "PWD=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -77,8 +77,9 @@ jobs:
           ruby-version: '3.1'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - id: set-matrix
-        run: bundle exec rake ci:set-matrix
+      - name: Set matrix output
+        id: set-matrix
+        run: echo "matrix=$(bundle exec rake ci:set-matrix)" >> $GITHUB_OUTPUT
 
   build-all-images:
     runs-on: ubuntu-latest

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -20,6 +20,8 @@ namespace :ci do
     end.to_json
 
     puts 'setting matrix output'
+    puts docker_contexts
+    puts "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT"
 
     # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -20,6 +20,9 @@ namespace :ci do
     end.to_json
 
     puts 'setting matrix output'
-    system('echo', "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT")
+
+    # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+    # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+    system('echo', "\"MATRIX=#{docker_contexts}\" >> $GITHUB_OUTPUT")
   end
 end

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -20,12 +20,10 @@ namespace :ci do
     end.to_json
 
     puts 'setting matrix output'
-    puts docker_contexts
-    puts "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT"
-    puts "parsed: #{JSON.parse(docker_contexts)}"
 
     # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
     system('echo', "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT")
+    system('echo', "$GITHUB_OUTPUT")
   end
 end

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -15,15 +15,12 @@ namespace :ci do
         path.include?('examples')
     end
 
+    # adding a puts here just returns an enumartor (i think this is rake's fault)
+    # so we set it to a variable and the use puts on that
     docker_contexts = dockerfiles.map do |path|
       Pathname.new(path).relative_path_from(Util::PROJECT_PATHNAME).dirname + Util::BAKE_FILE
     end.to_json
 
-    puts 'setting matrix output'
-
-    # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
-    # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-    system('echo', "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT")
-    system('echo', "$GITHUB_OUTPUT")
+    puts docker_contexts
   end
 end

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -23,6 +23,6 @@ namespace :ci do
 
     # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-    system('echo', "\"MATRIX=#{docker_contexts}\" >> $GITHUB_OUTPUT")
+    system('echo', "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT")
   end
 end

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -22,6 +22,7 @@ namespace :ci do
     puts 'setting matrix output'
     puts docker_contexts
     puts "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT"
+    puts "parsed: #{JSON.parse(docker_contexts)}"
 
     # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -20,6 +20,6 @@ namespace :ci do
     end.to_json
 
     puts 'setting matrix output'
-    system('echo', "::set-output name=matrix::#{docker_contexts}")
+    system('echo', "\"matrix=#{docker_contexts}\" >> $GITHUB_OUTPUT")
   end
 end


### PR DESCRIPTION
- Run set-matrix step earlier for faster builds
- Fix set-output deprecation
- Change rake task so that we set GitHub specific variables in the workflow
    and gain better portability