### PR TITLE
Bump bundler to v2.4.5

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -74,7 +74,7 @@ java:
 ruby: &RUBY
   defaults:
     base_image: 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core
-    bundler_version: 2.3.14
+    bundler_version: 2.4.5
     rubygems_version: 3.3.14
     flavor: slim
   versions:

--- a/ruby/2.7-fat/Dockerfile
+++ b/ruby/2.7-fat/Dockerfile
@@ -5,7 +5,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:latest
+FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core
 LABEL com.get-bridge.image.authors="get-bridge"
 
 USER root
@@ -51,7 +51,7 @@ install: --no-document
 update: --no-document
 EOT
 
-ENV BUNDLER_VERSION 2.3.14
+ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.3.14
 ENV RUBY_DOWNLOAD_SHA256 54dcd3044726c4ab75a9d4604720501442b229a3aed6a55fe909567da8807f24

--- a/ruby/2.7/Dockerfile
+++ b/ruby/2.7/Dockerfile
@@ -5,7 +5,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:latest
+FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core
 LABEL com.get-bridge.image.authors="get-bridge"
 
 USER root
@@ -51,7 +51,7 @@ install: --no-document
 update: --no-document
 EOT
 
-ENV BUNDLER_VERSION 2.3.14
+ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.3.14
 ENV RUBY_DOWNLOAD_SHA256 54dcd3044726c4ab75a9d4604720501442b229a3aed6a55fe909567da8807f24

--- a/ruby/3.0-fat/Dockerfile
+++ b/ruby/3.0-fat/Dockerfile
@@ -5,7 +5,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:latest
+FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core
 LABEL com.get-bridge.image.authors="get-bridge"
 
 USER root
@@ -51,7 +51,7 @@ install: --no-document
 update: --no-document
 EOT
 
-ENV BUNDLER_VERSION 2.3.14
+ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.3.14
 ENV RUBY_DOWNLOAD_SHA256 8e22fc7304520435522253210ed0aa9a50545f8f13c959fe01a05aea06bef2f0

--- a/ruby/3.0/Dockerfile
+++ b/ruby/3.0/Dockerfile
@@ -5,7 +5,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:latest
+FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core
 LABEL com.get-bridge.image.authors="get-bridge"
 
 USER root
@@ -51,7 +51,7 @@ install: --no-document
 update: --no-document
 EOT
 
-ENV BUNDLER_VERSION 2.3.14
+ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.3.14
 ENV RUBY_DOWNLOAD_SHA256 8e22fc7304520435522253210ed0aa9a50545f8f13c959fe01a05aea06bef2f0

--- a/ruby/3.1-fat/Dockerfile
+++ b/ruby/3.1-fat/Dockerfile
@@ -5,7 +5,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:latest
+FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core
 LABEL com.get-bridge.image.authors="get-bridge"
 
 USER root
@@ -33,7 +33,7 @@ install: --no-document
 update: --no-document
 EOT
 
-ENV BUNDLER_VERSION 2.3.14
+ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.3.14
 ENV RUBY_DOWNLOAD_SHA256 ca10d017f8a1b6d247556622c841fc56b90c03b1803f87198da1e4fd3ec3bf2a

--- a/ruby/3.1/Dockerfile
+++ b/ruby/3.1/Dockerfile
@@ -5,7 +5,7 @@
 # task `rake generate:ruby`
 
 ########## Ruby image ##########################
-FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core:latest
+FROM 127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/core
 LABEL com.get-bridge.image.authors="get-bridge"
 
 USER root
@@ -33,7 +33,7 @@ install: --no-document
 update: --no-document
 EOT
 
-ENV BUNDLER_VERSION 2.3.14
+ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.3.14
 ENV RUBY_DOWNLOAD_SHA256 ca10d017f8a1b6d247556622c841fc56b90c03b1803f87198da1e4fd3ec3bf2a


### PR DESCRIPTION
The removal of `:latest` is a residual change from bcfd6f3ccddc25a3591f887be1d0aeef1b562a91

Closes: BRD-11105