### PR TITLE
Add all available java images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
+      fail-fast: false
       # Build the core images first using the matrix strategy, from there, we will get a list
       # of other docker images to build concurrently.
       matrix:
@@ -92,6 +93,7 @@ jobs:
       - set-matrix
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
+      fail-fast: false
       matrix:
         ci-files: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     steps:

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -22,7 +22,7 @@ RUN <<EOT
 
   # Check that java commands work
   [ "$(command -v java)" = '/usr/bin/java' ]
-  java --version
+  java -version
 EOT
 
 USER docker

--- a/java/17-jre/Dockerfile
+++ b/java/17-jre/Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    openjdk-17-jre
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/17-jre/docker-bake.hcl
+++ b/java/17-jre/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:17-jre", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:17-jre-jammy"]
+  context = "${PWD}/java/17-jre"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/17-jre"
+  ]
+  cache-to = [
+    "type=gha,scope=java/17-jre,mode=max"
+  ]
+}

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    openjdk-17-jdk
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/17/docker-bake.hcl
+++ b/java/17/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:17", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:17-jdk", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:17-jdk-jammy"]
+  context = "${PWD}/java/17"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/17"
+  ]
+  cache-to = [
+    "type=gha,scope=java/17,mode=max"
+  ]
+}

--- a/java/18-jre/Dockerfile
+++ b/java/18-jre/Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    openjdk-18-jre
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/18-jre/docker-bake.hcl
+++ b/java/18-jre/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:18-jre", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:18-jre-jammy"]
+  context = "${PWD}/java/18-jre"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/18-jre"
+  ]
+  cache-to = [
+    "type=gha,scope=java/18-jre,mode=max"
+  ]
+}

--- a/java/18/Dockerfile
+++ b/java/18/Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    openjdk-18-jdk
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/18/docker-bake.hcl
+++ b/java/18/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:18", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:18-jdk", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:18-jdk-jammy"]
+  context = "${PWD}/java/18"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/18"
+  ]
+  cache-to = [
+    "type=gha,scope=java/18,mode=max"
+  ]
+}

--- a/java/19-jre/Dockerfile
+++ b/java/19-jre/Dockerfile
@@ -17,7 +17,9 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    ca-certificates-java
+  apt-get install --yes --no-install-recommends \
+    openjdk-19-jre
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/19-jre/docker-bake.hcl
+++ b/java/19-jre/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:19-jre", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:19-jre-jammy"]
+  context = "${PWD}/java/19-jre"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/19-jre"
+  ]
+  cache-to = [
+    "type=gha,scope=java/19-jre,mode=max"
+  ]
+}

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -17,7 +17,9 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    ca-certificates-java
+  apt-get install --yes --no-install-recommends \
+    openjdk-19-jdk
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/19/docker-bake.hcl
+++ b/java/19/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:19", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:19-jdk", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:19-jdk-jammy"]
+  context = "${PWD}/java/19"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/19"
+  ]
+  cache-to = [
+    "type=gha,scope=java/19,mode=max"
+  ]
+}

--- a/java/8-jre/Dockerfile
+++ b/java/8-jre/Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    openjdk-8-jre
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/8-jre/docker-bake.hcl
+++ b/java/8-jre/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:8-jre", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:8-jre-jammy"]
+  context = "${PWD}/java/8-jre"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/8-jre"
+  ]
+  cache-to = [
+    "type=gha,scope=java/8-jre,mode=max"
+  ]
+}

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    openjdk-11-jre
+    openjdk-8-jdk
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work

--- a/java/8/docker-bake.hcl
+++ b/java/8/docker-bake.hcl
@@ -1,0 +1,24 @@
+# GENERATED FILE, DO NOT MODIFY!
+# To update this file please edit the relevant template and run the generation
+# task `rake generate:java`
+
+# https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition
+
+variable "PWD" {default="" }
+
+group "default" {
+  targets = ["java"]
+}
+
+# NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
+target "java" {
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:8", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:8-jdk", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/java:8-jdk-jammy"]
+  context = "${PWD}/java/8"
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = [
+    "type=gha,scope=java/8"
+  ]
+  cache-to = [
+    "type=gha,scope=java/8,mode=max"
+  ]
+}

--- a/java/template/Dockerfile
+++ b/java/template/Dockerfile
@@ -14,13 +14,17 @@ RUN <<EOT
   mkdir -p /usr/src/app
   chown docker:docker /usr/src/app
   apt-get update
+  <%- if java_version == 19 -%>
+  apt-get install --yes --no-install-recommends \
+    ca-certificates-java
+  <%- end -%>
   apt-get install --yes --no-install-recommends \
     openjdk-<%= java_version %>-<%= flavor %>
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 
   # Check that java commands work
   [ "$(command -v java)" = '/usr/bin/java' ]
-  java --version
+  java -version
 EOT
 
 USER docker

--- a/manifest.yml
+++ b/manifest.yml
@@ -64,11 +64,35 @@ java:
     #   distro: jammy
     #   flavor: jdk
     #   java_version: 11
+    '8':
+      java_version: 8
+      flavor: jdk
+    '8-jre':
+      java_version: 8
+      flavor: jre
     '11':
       java_version: 11
       flavor: jdk
     '11-jre':
       java_version: 11
+      flavor: jre
+    '17':
+      java_version: 17
+      flavor: jdk
+    '17-jre':
+      java_version: 17
+      flavor: jre
+    '18':
+      java_version: 18
+      flavor: jdk
+    '18-jre':
+      java_version: 18
+      flavor: jre
+    '19':
+      java_version: 19
+      flavor: jdk
+    '19-jre':
+      java_version: 19
       flavor: jre
 
 ruby: &RUBY


### PR DESCRIPTION
Adds:
- java:8
- java:8-jre
- java:17
- java:17-jre
- java:18
- java:18-jre
- java:19
- java:19-jre

Note: There is a pretty big workaround for java:19(-jre) due to an issue with ca-certificates-java not handling a post install script correctly. I can't seem to replicate the issue locally however. Sooner or later that workaround should be removed when the build is no longer failing without the workaround. See here:
https://github.com/get-bridge/docker-base-images/pull/70/files#diff-fa1a7d7ca3ea5b4b9377f24cc9ef046efb0b6e8f87f3f4fcbb26db52584d7b8bR17-R20