### PR TITLE
Remove java:19 ca-certificates-java workaround

### DIFF
--- a/java/19-jre/Dockerfile
+++ b/java/19-jre/Dockerfile
@@ -17,8 +17,6 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    ca-certificates-java
-  apt-get install --yes --no-install-recommends \
     openjdk-19-jre
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -17,8 +17,6 @@ RUN <<EOT
   chown docker:docker /usr/src/app
   apt-get update
   apt-get install --yes --no-install-recommends \
-    ca-certificates-java
-  apt-get install --yes --no-install-recommends \
     openjdk-19-jdk
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*
 

--- a/java/template/Dockerfile
+++ b/java/template/Dockerfile
@@ -14,10 +14,6 @@ RUN <<EOT
   mkdir -p /usr/src/app
   chown docker:docker /usr/src/app
   apt-get update
-  <%- if java_version == 19 -%>
-  apt-get install --yes --no-install-recommends \
-    ca-certificates-java
-  <%- end -%>
   apt-get install --yes --no-install-recommends \
     openjdk-<%= java_version %>-<%= flavor %>
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/*


### PR DESCRIPTION
Once this is passing CI, we can remove this workaround. 