### PR TITLE
Fix dependabot auth, 2nd try

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ registries:
   ecr:
     type: docker-registry
     url: ${{ vars.ECR_REGISTRY }}
-    key: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
-    token: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
+    username: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
+    password: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Dependabot apparently doesn't expect these keys, given this error:

```
The property '#/registries/ecr/' did not contain a required property of 'username'
The property '#/registries/ecr/' did not contain a required property of 'password'
The property '#/registries/ecr/' contains additional properties ["key", "token"] outside of the schema when none are allowed
```