### PR TITLE
Fix url, must include https://

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ version: 2
 registries:
   ecr:
     type: docker-registry
-    url: ${{ vars.ECR_REGISTRY }}
+    url: https://${{ vars.ECR_REGISTRY }}
     username: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
     password: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
 updates:


### PR DESCRIPTION
This fixes the following dependabot error:

    Docker registries must specify a url in the format like `https://registry-host.io:5000` or `https://example.dkr.ecr.region.amazonaws.com`.
