### PR TITLE
Add a max parallel of 4

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -111,6 +111,7 @@ jobs:
       packages: write
       contents: read
     strategy:
+      max-parallel: 4
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.non_core_matrix) }}
     timeout-minutes: 120


### PR DESCRIPTION
Closes: #92 

With unlimited parallelization, it's quite common for the jobs to be pushing multiple image layers simultaneously (especially for cached builds it seems!) so we frequently get failures related to #92. Adding a `max-parallel` of 4 should hopefully reduce the frequency of these kind of job failures.