### PR TITLE
Bump ruby versions, latest: v3.2.2

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -185,29 +185,29 @@ ruby: &RUBY
   versions:
     '2.7': &RUBY27
       ruby_major: 2.7
-      ruby_version: 2.7.7
-      ruby_download_sha256: b38dff2e1f8ce6e5b7d433f8758752987a6b2adfd9bc7571dbc42ea5d04e3e4c
+      ruby_version: 2.7.8
+      ruby_download_sha256: f22f662da504d49ce2080e446e4bea7008cee11d5ec4858fc69000d0e5b1d7fb
     '2.7-fat':
       <<: *RUBY27
       flavor: fat
     '3.0': &RUBY30
       ruby_major: 3.0
-      ruby_version: 3.0.5
-      ruby_download_sha256: cf7cb5ba2030fe36596a40980cdecfd79a0337d35860876dc2b10a38675bddde
+      ruby_version: 3.0.6
+      ruby_download_sha256: b5cbee93e62d85cfb2a408c49fa30a74231ae8409c2b3858e5f5ea254d7ddbd1
     '3.0-fat':
       <<: *RUBY30
       flavor: fat
     '3.1': &RUBY31
       ruby_major: 3.1
-      ruby_version: 3.1.3
-      ruby_download_sha256: 4ee161939826bcdfdafa757cf8e293a7f14e357f62be7144f040335cc8c7371a
+      ruby_version: 3.1.4
+      ruby_download_sha256: 1b6d6010e76036c937b9671f4752f065aeca800a6c664f71f6c9a699453af94f
     '3.1-fat':
       <<: *RUBY31
       flavor: fat
     '3.2': &RUBY32
       ruby_major: 3.2
-      ruby_version: 3.2.0
-      ruby_download_sha256: d2f4577306e6dd932259693233141e5c3ec13622c95b75996541b8d5b68b28b4
+      ruby_version: 3.2.2
+      ruby_download_sha256: 4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710975149e23
       latest: true # apply the latest tag
     '3.2-fat':
       <<: *RUBY32

--- a/ruby/2.7-fat/Dockerfile
+++ b/ruby/2.7-fat/Dockerfile
@@ -55,9 +55,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 b38dff2e1f8ce6e5b7d433f8758752987a6b2adfd9bc7571dbc42ea5d04e3e4c
+ENV RUBY_DOWNLOAD_SHA256 f22f662da504d49ce2080e446e4bea7008cee11d5ec4858fc69000d0e5b1d7fb
 ENV RUBY_MAJOR 2.7
-ENV RUBY_VERSION 2.7.7
+ENV RUBY_VERSION 2.7.8
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/2.7-fat/docker-bake.hcl
+++ b/ruby/2.7-fat/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.7-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.7-fat-jammy"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.8-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.8-fat-jammy"]
   context = "${PWD}/ruby/2.7-fat"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/2.7/Dockerfile
+++ b/ruby/2.7/Dockerfile
@@ -55,9 +55,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 b38dff2e1f8ce6e5b7d433f8758752987a6b2adfd9bc7571dbc42ea5d04e3e4c
+ENV RUBY_DOWNLOAD_SHA256 f22f662da504d49ce2080e446e4bea7008cee11d5ec4858fc69000d0e5b1d7fb
 ENV RUBY_MAJOR 2.7
-ENV RUBY_VERSION 2.7.7
+ENV RUBY_VERSION 2.7.8
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/2.7/docker-bake.hcl
+++ b/ruby/2.7/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.7", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.7-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.7-slim-jammy"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.8", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.8-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7.8-slim-jammy"]
   context = "${PWD}/ruby/2.7"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/3.0-fat/Dockerfile
+++ b/ruby/3.0-fat/Dockerfile
@@ -55,9 +55,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 cf7cb5ba2030fe36596a40980cdecfd79a0337d35860876dc2b10a38675bddde
+ENV RUBY_DOWNLOAD_SHA256 b5cbee93e62d85cfb2a408c49fa30a74231ae8409c2b3858e5f5ea254d7ddbd1
 ENV RUBY_MAJOR 3.0
-ENV RUBY_VERSION 3.0.5
+ENV RUBY_VERSION 3.0.6
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/3.0-fat/docker-bake.hcl
+++ b/ruby/3.0-fat/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.5-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.5-fat-jammy"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.6-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.6-fat-jammy"]
   context = "${PWD}/ruby/3.0-fat"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/3.0/Dockerfile
+++ b/ruby/3.0/Dockerfile
@@ -55,9 +55,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 cf7cb5ba2030fe36596a40980cdecfd79a0337d35860876dc2b10a38675bddde
+ENV RUBY_DOWNLOAD_SHA256 b5cbee93e62d85cfb2a408c49fa30a74231ae8409c2b3858e5f5ea254d7ddbd1
 ENV RUBY_MAJOR 3.0
-ENV RUBY_VERSION 3.0.5
+ENV RUBY_VERSION 3.0.6
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/3.0/docker-bake.hcl
+++ b/ruby/3.0/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.5", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.5-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.5-slim-jammy"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.6", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.6-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0.6-slim-jammy"]
   context = "${PWD}/ruby/3.0"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/3.1-fat/Dockerfile
+++ b/ruby/3.1-fat/Dockerfile
@@ -37,9 +37,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 4ee161939826bcdfdafa757cf8e293a7f14e357f62be7144f040335cc8c7371a
+ENV RUBY_DOWNLOAD_SHA256 1b6d6010e76036c937b9671f4752f065aeca800a6c664f71f6c9a699453af94f
 ENV RUBY_MAJOR 3.1
-ENV RUBY_VERSION 3.1.3
+ENV RUBY_VERSION 3.1.4
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/3.1-fat/docker-bake.hcl
+++ b/ruby/3.1-fat/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.3-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.3-fat-jammy"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.4-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.4-fat-jammy"]
   context = "${PWD}/ruby/3.1-fat"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/3.1/Dockerfile
+++ b/ruby/3.1/Dockerfile
@@ -37,9 +37,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 4ee161939826bcdfdafa757cf8e293a7f14e357f62be7144f040335cc8c7371a
+ENV RUBY_DOWNLOAD_SHA256 1b6d6010e76036c937b9671f4752f065aeca800a6c664f71f6c9a699453af94f
 ENV RUBY_MAJOR 3.1
-ENV RUBY_VERSION 3.1.3
+ENV RUBY_VERSION 3.1.4
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/3.1/docker-bake.hcl
+++ b/ruby/3.1/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.3", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.3-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.3-slim-jammy"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.4", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.4-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1.4-slim-jammy"]
   context = "${PWD}/ruby/3.1"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/3.2-fat/Dockerfile
+++ b/ruby/3.2-fat/Dockerfile
@@ -37,9 +37,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 d2f4577306e6dd932259693233141e5c3ec13622c95b75996541b8d5b68b28b4
+ENV RUBY_DOWNLOAD_SHA256 4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710975149e23
 ENV RUBY_MAJOR 3.2
-ENV RUBY_VERSION 3.2.0
+ENV RUBY_VERSION 3.2.2
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/3.2-fat/docker-bake.hcl
+++ b/ruby/3.2-fat/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.0-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.0-fat-jammy"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-fat-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.2-fat", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.2-fat-jammy"]
   context = "${PWD}/ruby/3.2-fat"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/3.2/Dockerfile
+++ b/ruby/3.2/Dockerfile
@@ -37,9 +37,9 @@ EOT
 ENV BUNDLER_VERSION 2.4.5
 ENV LANG en_US.utf-8
 ENV RUBYGEMS_VERSION 3.4.5
-ENV RUBY_DOWNLOAD_SHA256 d2f4577306e6dd932259693233141e5c3ec13622c95b75996541b8d5b68b28b4
+ENV RUBY_DOWNLOAD_SHA256 4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710975149e23
 ENV RUBY_MAJOR 3.2
-ENV RUBY_VERSION 3.2.0
+ENV RUBY_VERSION 3.2.2
 
 # NOTE: some of ruby's build scripts are written in ruby so we need to install ruby
 # in order to compile ruby. We use apt-mark to uninstall packages we don't need.

--- a/ruby/3.2/docker-bake.hcl
+++ b/ruby/3.2/docker-bake.hcl
@@ -12,7 +12,7 @@ group "default" {
 
 # NOTE: the context is required for now due to https://github.com/docker/buildx/issues/1028
 target "ruby" {
-  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.0", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.0-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.0-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:latest"]
+  tags = ["127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.2", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.2-slim", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2.2-slim-jammy", "127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:latest"]
   context = "${PWD}/ruby/3.2"
   platforms = ["linux/amd64", "linux/arm64"]
   cache-from = [

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -6,11 +6,11 @@ development and testing and include development libraries for easy building
 of production assets.
 
 Available tags:
-- [`3.2`, `3.2-slim`, `3.2-slim-jammy`, `3.2.0`, `3.2.0-slim`, `3.2.0-slim-jammy`, `latest`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2)
-- [`3.2-fat`, `3.2-fat-jammy`, `3.2.0-fat`, `3.2.0-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-fat)
-- [`3.1`, `3.1-slim`, `3.1-slim-jammy`, `3.1.3`, `3.1.3-slim`, `3.1.3-slim-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1)
-- [`3.1-fat`, `3.1-fat-jammy`, `3.1.3-fat`, `3.1.3-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat)
-- [`3.0`, `3.0-slim`, `3.0-slim-jammy`, `3.0.5`, `3.0.5-slim`, `3.0.5-slim-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0)
-- [`3.0-fat`, `3.0-fat-jammy`, `3.0.5-fat`, `3.0.5-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat)
-- [`2.7`, `2.7-slim`, `2.7-slim-jammy`, `2.7.7`, `2.7.7-slim`, `2.7.7-slim-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7)
-- [`2.7-fat`, `2.7-fat-jammy`, `2.7.7-fat`, `2.7.7-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat)
+- [`3.2`, `3.2-slim`, `3.2-slim-jammy`, `3.2.2`, `3.2.2-slim`, `3.2.2-slim-jammy`, `latest`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2)
+- [`3.2-fat`, `3.2-fat-jammy`, `3.2.2-fat`, `3.2.2-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.2-fat)
+- [`3.1`, `3.1-slim`, `3.1-slim-jammy`, `3.1.4`, `3.1.4-slim`, `3.1.4-slim-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1)
+- [`3.1-fat`, `3.1-fat-jammy`, `3.1.4-fat`, `3.1.4-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.1-fat)
+- [`3.0`, `3.0-slim`, `3.0-slim-jammy`, `3.0.6`, `3.0.6-slim`, `3.0.6-slim-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0)
+- [`3.0-fat`, `3.0-fat-jammy`, `3.0.6-fat`, `3.0.6-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:3.0-fat)
+- [`2.7`, `2.7-slim`, `2.7-slim-jammy`, `2.7.8`, `2.7.8-slim`, `2.7.8-slim-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7)
+- [`2.7-fat`, `2.7-fat-jammy`, `2.7.8-fat`, `2.7.8-fat-jammy`](127178877223.dkr.ecr.us-east-2.amazonaws.com/get-bridge/ruby:2.7-fat)


### PR DESCRIPTION
Update Ruby versions:

- [Ruby 3.2.2 Released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/)
- [Ruby 3.1.4 Released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-1-4-released/)
- [Ruby 3.0.6 Released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-0-6-released/)
- [Ruby 2.7.8 Released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/)