### PR TITLE
update ruby to 3.0.7

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -27,11 +27,11 @@ jobs:
       clojure_matrix: ${{ steps.set-matrix.outputs.clojure_matrix }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4.1.2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: ruby/setup-ruby@v1.173.0
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true

--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -12,11 +12,11 @@ jobs:
   publish-techdocs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4
 
-      - uses: actions/setup-python@v4.8.0
+      - uses: actions/setup-python@v4
 
       - name: Install techdocs-cli
         run: sudo npm install -g @techdocs/cli

--- a/manifest.yml
+++ b/manifest.yml
@@ -198,8 +198,8 @@ ruby: &RUBY
       flavor: fat
     '3.0': &RUBY30
       ruby_major: 3.0
-      ruby_version: 3.0.6
-      ruby_download_sha256: b5cbee93e62d85cfb2a408c49fa30a74231ae8409c2b3858e5f5ea254d7ddbd1
+      ruby_version: 3.0.7
+      ruby_download_sha256: 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
     '3.0-fat':
       <<: *RUBY30
       flavor: fat


### PR DESCRIPTION
Update ruby to 3.0.7 and bump GitHub Action versions.

---
_Note: this PR's title/description were briefly edited by mistake by an automated tool on 2026-07-09 and have been restored to reflect the original change._